### PR TITLE
fix: content.replace error in parse table

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,10 +36,10 @@
     <!-- <link href="https://fonts.googleapis.com/css?family=Playfair+Display:700,900" rel="stylesheet" /> -->
     <link href="static/css/app.css" rel="stylesheet">
     <script src="static/js/jquery-3.3.1.min.js"></script>
-    <script src="lib.js" type="text/javascript"></script>
-    <script src="do_parse_table.js" type="text/javascript"></script>
-    <script src="render_tree.js" type="text/javascript"></script>
-    <script src="main.js" type="text/javascript"></script>
+    <script src="lib.js?v=2.0.0" type="text/javascript"></script>
+    <script src="do_parse_table.js?v=2.0.0" type="text/javascript"></script>
+    <script src="render_tree.js?v=2.0.0" type="text/javascript"></script>
+    <script src="main.js?v=2.0.0" type="text/javascript"></script>
 </head>
 
 <body>


### PR DESCRIPTION
Add version query parameters (v=2.0.0) to all JavaScript file includes to prevent browsers from using cached versions that may contain bugs.

This resolves the "content.replace is not a function" error that users experience when their browser caches an older version of do_parse_table.js before the array handling fix was applied.

The actual bug was already fixed in commit 53279ce, but users with cached versions still experience the error. This ensures all users get the latest fixed version.